### PR TITLE
feat: define record used to store connection ID structure

### DIFF
--- a/lib/ultravisor/manager.ex
+++ b/lib/ultravisor/manager.ex
@@ -7,7 +7,10 @@
 defmodule Ultravisor.Manager do
   @moduledoc false
   use GenServer, restart: :transient
+
   require Logger
+
+  import Ultravisor, only: [conn_id: 1]
 
   alias Ultravisor.Helpers
   alias Ultravisor.Protocol.Server
@@ -45,7 +48,7 @@ defmodule Ultravisor.Manager do
 
     [args | _] = Enum.filter(args.replicas, fn e -> e.replica_type == :write end)
 
-    {{type, tenant}, user, _mode, db_name, _search_path} = args.id
+    conn_id(type: type, tenant: tenant, user: user, db_name: db_name) = args.id
 
     state = %{
       id: args.id,

--- a/lib/ultravisor/metrics_cleaner.ex
+++ b/lib/ultravisor/metrics_cleaner.ex
@@ -8,6 +8,7 @@ defmodule Ultravisor.MetricsCleaner do
   @moduledoc false
 
   use GenServer
+
   require Logger
 
   @interval :timer.minutes(30)
@@ -82,15 +83,15 @@ defmodule Ultravisor.MetricsCleaner do
       fn elem, acc ->
         with {{_,
                %{
-                 type: type,
-                 mode: mode,
-                 user: user,
-                 tenant: tenant,
-                 db_name: db,
-                 search_path: search_path
-               }} = key, _} <- elem,
-             [] <-
-               :ets.lookup(@tenant_registry_table, {{type, tenant}, user, mode, db, search_path}) do
+                 type: _type,
+                 mode: _mode,
+                 user: _user,
+                 tenant: _tenant,
+                 db_name: _db,
+                 search_path: _search_path
+               } = map} = key, _} <- elem,
+             id = Ultravisor.map_to_conn_id(map),
+             [] <- :ets.lookup(@tenant_registry_table, id) do
           Logger.warning("Found orphaned metric: #{inspect(key)}")
           :ets.delete(tid, key)
 

--- a/lib/ultravisor/monitoring/tenant.ex
+++ b/lib/ultravisor/monitoring/tenant.ex
@@ -10,8 +10,6 @@ defmodule Ultravisor.PromEx.Plugins.Tenant do
   use PromEx.Plugin
   require Logger
 
-  alias Ultravisor, as: S
-
   @tags [:tenant, :user, :mode, :type, :db_name, :search_path]
 
   @impl true
@@ -212,19 +210,12 @@ defmodule Ultravisor.PromEx.Plugins.Tenant do
     |> Enum.each(&emit_telemetry_for_tenant/1)
   end
 
-  @spec emit_telemetry_for_tenant({S.id(), non_neg_integer()}) :: :ok
-  def emit_telemetry_for_tenant({{{type, tenant}, user, mode, db_name, search_path}, count}) do
+  @spec emit_telemetry_for_tenant({Ultravisor.id(), non_neg_integer()}) :: :ok
+  def emit_telemetry_for_tenant({id, count}) do
     :telemetry.execute(
       [:ultravisor, :connections],
       %{active: count},
-      %{
-        tenant: tenant,
-        user: user,
-        mode: mode,
-        type: type,
-        db_name: db_name,
-        search_path: search_path
-      }
+      Ultravisor.conn_id_to_map(id)
     )
   end
 
@@ -251,19 +242,12 @@ defmodule Ultravisor.PromEx.Plugins.Tenant do
     |> Enum.each(&emit_proxy_telemetry_for_tenant/1)
   end
 
-  @spec emit_proxy_telemetry_for_tenant({S.id(), non_neg_integer()}) :: :ok
-  def emit_proxy_telemetry_for_tenant({{{type, tenant}, user, mode, db_name, search_path}, count}) do
+  @spec emit_proxy_telemetry_for_tenant({Ultravisor.id(), non_neg_integer()}) :: :ok
+  def emit_proxy_telemetry_for_tenant({id, count}) do
     :telemetry.execute(
       [:ultravisor, :proxy, :connections],
       %{active: count},
-      %{
-        tenant: tenant,
-        user: user,
-        mode: mode,
-        type: type,
-        db_name: db_name,
-        search_path: search_path
-      }
+      Ultravisor.conn_id_to_map(id)
     )
   end
 

--- a/lib/ultravisor/syn_handler.ex
+++ b/lib/ultravisor/syn_handler.ex
@@ -13,10 +13,12 @@ defmodule Ultravisor.SynHandler do
 
   require Logger
 
+  import Ultravisor, only: [conn_id: 1]
+
   @impl true
   def on_process_unregistered(
         :tenants,
-        {{type, tenant}, user, mode, db_name, _search_path} = id,
+        conn_id(type: type, tenant: tenant, user: user, mode: mode, db_name: db_name) = id,
         _pid,
         meta,
         reason

--- a/lib/ultravisor/tenant_supervisor.ex
+++ b/lib/ultravisor/tenant_supervisor.ex
@@ -9,6 +9,9 @@ defmodule Ultravisor.TenantSupervisor do
   use Supervisor
 
   require Logger
+
+  import Ultravisor, only: [conn_id: 1]
+
   alias Ultravisor.Manager
   alias Ultravisor.SecretChecker
 
@@ -42,7 +45,15 @@ defmodule Ultravisor.TenantSupervisor do
 
     children = [{Manager, args}, {SecretChecker, args} | pools]
 
-    {{type, tenant}, user, mode, db_name, search_path} = args.id
+    conn_id(
+      type: type,
+      tenant: tenant,
+      user: user,
+      mode: mode,
+      db_name: db_name,
+      search_path: search_path
+    ) = args.id
+
     map_id = %{user: user, mode: mode, type: type, db_name: db_name, search_path: search_path}
     Registry.register(Ultravisor.Registry.TenantSups, tenant, map_id)
 

--- a/test/support/e2e_case.ex
+++ b/test/support/e2e_case.ex
@@ -11,6 +11,8 @@ defmodule Ultravisor.E2ECase do
 
   use ExUnit.CaseTemplate
 
+  import Ultravisor, only: [conn_id: 1]
+
   @repo Ultravisor.Repo
 
   using do
@@ -65,8 +67,15 @@ defmodule Ultravisor.E2ECase do
              })
 
     on_exit(fn ->
-      _ = Ultravisor.stop({{:single, external_id}, "postgres", :session, external_id, nil})
-      _ = Ultravisor.stop({{:single, external_id}, "postgres", :transaction, external_id, nil})
+      _ =
+        Ultravisor.stop(
+          conn_id(tenant: external_id, user: "postgres", mode: :session, db_name: external_id)
+        )
+
+      _ =
+        Ultravisor.stop(
+          conn_id(tenant: external_id, user: "postgres", mode: :transaction, db_name: external_id)
+        )
 
       unboxed(fn ->
         assert {:ok, _} = @repo.query("DROP DATABASE #{external_id}")

--- a/test/ultravisor/db_handler_test.exs
+++ b/test/ultravisor/db_handler_test.exs
@@ -7,10 +7,11 @@
 defmodule Ultravisor.DbHandlerTest do
   use ExUnit.Case, async: true
 
+  import Ultravisor, only: [conn_id: 1]
+
   alias Ultravisor.DbHandler, as: Db
 
-  # import Mock
-  @id {{:single, "tenant"}, "user", :transaction, "postgres", nil}
+  @id conn_id(tenant: "tenant", user: "user", db_name: "postgres")
 
   defp sockpair do
     {:ok, listen} = :gen_tcp.listen(0, mode: :binary, active: false)

--- a/test/ultravisor/metrics_cleaner_test.exs
+++ b/test/ultravisor/metrics_cleaner_test.exs
@@ -7,6 +7,8 @@
 defmodule Ultravisor.MetricsCleanerTest do
   use ExUnit.Case, async: false
 
+  import Ultravisor, only: [conn_id: 1]
+
   alias Ultravisor.Monitoring.PromEx
   alias Ultravisor.PromEx.Plugins.Tenant, as: Metrics
 
@@ -27,10 +29,10 @@ defmodule Ultravisor.MetricsCleanerTest do
   end
 
   test "metrics for unknown tenant are removed" do
+    id = conn_id(tenant: "non-existent", user: "foo", db_name: "bar")
+
     :ok =
-      Metrics.emit_telemetry_for_tenant(
-        {{{:single, "non-existent"}, "foo", :transaction, "bar", nil}, 2137}
-      )
+      Metrics.emit_telemetry_for_tenant({id, 2137})
 
     metrics = PromEx.get_metrics()
 

--- a/test/ultravisor/monitoring/prom_ex_test.exs
+++ b/test/ultravisor/monitoring/prom_ex_test.exs
@@ -8,6 +8,8 @@ defmodule Ultravisor.Monitoring.PromExTest do
   use Ultravisor.DataCase, async: true
   use ExUnitProperties
 
+  import Ultravisor, only: [conn_id: 1]
+
   alias Ultravisor.Monitoring.Telem
 
   @subject Ultravisor.Monitoring.PromEx
@@ -47,10 +49,8 @@ defmodule Ultravisor.Monitoring.PromExTest do
       user = "user"
 
       check all(db_name <- string(:printable, min_length: 1, max_length: 63)) do
-        Telem.client_join(
-          :ok,
-          {{:single, tenant}, user, :session, db_name, nil}
-        )
+        id = conn_id(tenant: tenant, user: user, mode: :session, db_name: db_name)
+        Telem.client_join(:ok, id)
 
         metrics = @subject.get_metrics()
         file = Path.join(dir, "prom.out")
@@ -75,10 +75,8 @@ defmodule Ultravisor.Monitoring.PromExTest do
       db_name = "db_name"
 
       check all(user <- string(:printable, min_length: 1, max_length: 63)) do
-        Ultravisor.Monitoring.Telem.client_join(
-          :ok,
-          {{:single, tenant}, user, :session, db_name, nil}
-        )
+        id = conn_id(tenant: tenant, user: user, mode: :session, db_name: db_name)
+        Ultravisor.Monitoring.Telem.client_join(:ok, id)
 
         metrics = @subject.get_metrics()
         file = Path.join(dir, "prom.out")
@@ -103,10 +101,9 @@ defmodule Ultravisor.Monitoring.PromExTest do
       user = "user"
 
       check all(tenant <- string(:printable, min_length: 1)) do
-        Telem.client_join(
-          :ok,
-          {{:single, tenant}, user, :session, db_name, nil}
-        )
+        id = conn_id(tenant: tenant, user: user, mode: :session, db_name: db_name)
+
+        Telem.client_join(:ok, id)
 
         metrics = @subject.get_metrics()
         file = Path.join(dir, "prom.out")

--- a/test/ultravisor/syn_handler_test.exs
+++ b/test/ultravisor/syn_handler_test.exs
@@ -9,10 +9,12 @@ defmodule Ultravisor.SynHandlerTest do
 
   require Logger
 
+  import Ultravisor, only: [conn_id: 1]
+
   alias Ecto.Adapters.SQL.Sandbox
   alias Ultravisor.Support.Cluster
 
-  @id {{:single, "syn_tenant"}, "postgres", :session, "postgres", nil}
+  @id conn_id(tenant: "syn_tenant", user: "postgres", mode: :session, db_name: "postgres")
 
   @tag cluster: true
   test "resolving conflict" do


### PR DESCRIPTION
The reason for record over struct is that record, which is tuple based, has smaller memory footprint and is slightly faster in this scenario. Also we were using tuples previously, so record makes most sense there.