### PR TITLE
test: incorrect JWT secret used in API test

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -8,8 +8,8 @@ import Config
 
 config :ultravisor,
   region: "eu",
-  api_jwt_secret: "dev",
-  metrics_jwt_secret: "dev",
+  api_jwt_secret: "api-test-secret",
+  metrics_jwt_secret: "metrics-test-secret",
   jwt_claim_validators: %{},
   proxy_port_session: System.get_env("PROXY_PORT_SESSION", "7653") |> String.to_integer(),
   proxy_port_transaction: System.get_env("PROXY_PORT_TRANSACTION", "7654") |> String.to_integer(),

--- a/test/ultravisor_web/controllers/tenant_controller_test.exs
+++ b/test/ultravisor_web/controllers/tenant_controller_test.exs
@@ -176,7 +176,7 @@ defmodule UltravisorWeb.TenantControllerTest do
     assert {:ok, nil} = Cachex.get(Ultravisor.Cache, {:tenant_cache, external_id, nil})
   end
 
-  defp gen_token(secret \\ Application.fetch_env!(:ultravisor, :metrics_jwt_secret)) do
+  defp gen_token(secret \\ Application.fetch_env!(:ultravisor, :api_jwt_secret)) do
     Ultravisor.Jwt.Token.gen!(secret)
   end
 end


### PR DESCRIPTION
This was accidentally working during tests because both secrets were set to the same value. To avoid such issue in future I have changed secrets to be different.