### PR TITLE
test: remove flaky flag from test

### DIFF
--- a/lib/ultravisor_web/router.ex
+++ b/lib/ultravisor_web/router.ex
@@ -30,11 +30,13 @@ defmodule UltravisorWeb.Router do
 
   scope "/swaggerui" do
     pipe_through(:browser)
+
     get("/", OpenApiSpex.Plug.SwaggerUI, path: "/api/openapi")
   end
 
   scope "/api" do
     pipe_through(:openapi)
+
     get("/openapi", OpenApiSpex.Plug.RenderSpec, [])
   end
 

--- a/test/ultravisor/client_handler/stats_test.exs
+++ b/test/ultravisor/client_handler/stats_test.exs
@@ -108,7 +108,6 @@ defmodule Ultravisor.ClientHandler.StatsTest do
 
     @tag external_id: "metrics_tenant"
     # it depends on the connection setup order
-    @tag flaky: true
     test "another instance do not send events here", %{telemetry: telemetry} = ctx do
       assert {:ok, _pid, node} = Ultravisor.Support.Cluster.start_node()
 


### PR DESCRIPTION
This test seems to be stabilised now. Also with recent enabling of the CodeCov integration we can track flakiness more methodically, so this is not needed anymore there.