### PR TITLE
chore: remove connection type from ID

### DIFF
--- a/lib/ultravisor.ex
+++ b/lib/ultravisor.ex
@@ -26,7 +26,6 @@ defmodule Ultravisor do
   @max_pools Application.compile_env(:ultravisor, :max_pools, 20)
 
   Record.defrecord(:conn_id,
-    type: :single,
     tenant: nil,
     user: nil,
     mode: :transaction,
@@ -36,7 +35,6 @@ defmodule Ultravisor do
 
   @type id ::
           record(:conn_id,
-            type: :single | :cluster,
             tenant: String.t(),
             user: String.t(),
             mode: mode(),
@@ -46,7 +44,6 @@ defmodule Ultravisor do
 
   def conn_id_to_map(
         conn_id(
-          type: type,
           tenant: tenant,
           user: user,
           mode: mode,
@@ -55,7 +52,6 @@ defmodule Ultravisor do
         )
       ) do
     %{
-      type: type,
       tenant: tenant,
       user: user,
       mode: mode,
@@ -65,7 +61,6 @@ defmodule Ultravisor do
   end
 
   def map_to_conn_id(%{
-        type: type,
         tenant: tenant,
         user: user,
         mode: mode,
@@ -73,7 +68,6 @@ defmodule Ultravisor do
         search_path: search_path
       }) do
     conn_id(
-      type: type,
       tenant: tenant,
       user: user,
       mode: mode,
@@ -210,7 +204,7 @@ defmodule Ultravisor do
     Enum.reduce(keys, [], fn
       {:metrics, ^tenant} = key, acc -> del.(key, acc)
       {:secrets, ^tenant, ^user} = key, acc -> del.(key, acc)
-      {:user_cache, _, ^user, ^tenant, _} = key, acc -> del.(key, acc)
+      {:user_cache, ^user, ^tenant, _} = key, acc -> del.(key, acc)
       {:tenant_cache, ^tenant, _} = key, acc -> del.(key, acc)
       {:pool_config_cache, ^tenant, ^user} = key, acc -> del.(key, acc)
       _, acc -> acc
@@ -232,7 +226,7 @@ defmodule Ultravisor do
           case key do
             {:metrics, ^tenant} -> del.(key, acc)
             {:secrets, ^tenant, _} -> del.(key, acc)
-            {:user_cache, _, _, ^tenant, _} -> del.(key, acc)
+            {:user_cache, _, ^tenant, _} -> del.(key, acc)
             {:tenant_cache, ^tenant, _} -> del.(key, acc)
             {:pool_config_cache, ^tenant, _} -> del.(key, acc)
             _ -> acc
@@ -258,7 +252,7 @@ defmodule Ultravisor do
 
   @spec get_local_pool(id) :: map | pid | nil
   def get_local_pool(id) do
-    match = {{:pool, :_, :_, id}, :"$2", :"$3"}
+    match = {{:pool, :_, id}, :"$2", :"$3"}
     body = [{{:"$2", :"$3"}}]
 
     case Registry.select(@registry, [{match, [], body}]) do
@@ -326,23 +320,17 @@ defmodule Ultravisor do
   @spec start_local_pool(id, secrets, atom()) :: {:ok, pid} | {:error, any}
   def start_local_pool(id, secrets, log_level \\ nil)
 
-  def start_local_pool(conn_id(tenant: tenant, type: type) = id, secrets, log_level) do
+  def start_local_pool(conn_id(tenant: tenant) = id, secrets, log_level) do
     Logger.info("Starting pool(s) for #{inspect(id)}")
 
     user = elem(secrets, 1).().alias
 
-    case type do
-      :single -> Tenants.get_pool_config_cache(tenant, user)
-    end
+    Tenants.get_pool_config_cache(tenant, user)
     |> case do
       [_ | _] = replicas ->
         opts =
           Enum.map(replicas, fn replica ->
-            case replica do
-              %Tenants.Tenant{} = tenant ->
-                Map.put(tenant, :replica_type, :write)
-            end
-            |> supervisor_args(id, secrets, log_level)
+            supervisor_args(replica, id, secrets, log_level)
           end)
 
         DynamicSupervisor.start_child(
@@ -365,7 +353,7 @@ defmodule Ultravisor do
 
   defp supervisor_args(
          tenant_record,
-         conn_id(type: type, tenant: tenant, user: user, mode: mode, db_name: db_name) = id,
+         conn_id(tenant: tenant, user: user, mode: mode, db_name: db_name) = id,
          {method, secrets},
          log_level
        ) do
@@ -379,7 +367,6 @@ defmodule Ultravisor do
       default_pool_size: def_pool_size,
       default_max_clients: def_max_clients,
       client_idle_timeout: client_idle_timeout,
-      replica_type: replica_type,
       sni_hostname: sni_hostname,
       users: [
         %{
@@ -387,7 +374,6 @@ defmodule Ultravisor do
           db_password: db_pass,
           pool_size: pool_size,
           db_user_alias: alias,
-          # mode_type: mode_type,
           max_clients: max_clients
         }
       ]
@@ -421,8 +407,7 @@ defmodule Ultravisor do
 
     %{
       id: id,
-      tenant: {type, tenant},
-      replica_type: replica_type,
+      tenant: tenant,
       user: user,
       auth: auth,
       pool_size: pool_size,

--- a/lib/ultravisor/client_handler.ex
+++ b/lib/ultravisor/client_handler.ex
@@ -248,12 +248,12 @@ defmodule Ultravisor.ClientHandler do
     case Server.decode_startup_packet(bin) do
       {:ok, hello} ->
         Logger.debug("ClientHandler: Client startup message: #{inspect(hello)}")
-        {type, {user, tenant_or_alias, db_name}} = HandlerHelpers.parse_user_info(hello.payload)
+        {user, tenant_or_alias, db_name} = HandlerHelpers.parse_user_info(hello.payload)
 
         if Helpers.valid_name?(user) and Helpers.valid_name?(db_name) do
           log_level = maybe_change_log(hello)
           search_path = hello.payload["options"]["--search_path"]
-          event = {:hello, {type, {user, tenant_or_alias, db_name, search_path}}}
+          event = {:hello, {user, tenant_or_alias, db_name, search_path}}
           app_name = app_name(hello.payload["application_name"])
 
           {:keep_state, data(data, log_level: log_level, app_name: app_name),
@@ -284,19 +284,18 @@ defmodule Ultravisor.ClientHandler do
 
   def handle_event(
         :internal,
-        {:hello, {type, {user, tenant_or_alias, db_name, search_path}}},
+        {:hello, {user, tenant_or_alias, db_name, search_path}},
         :exchange,
         data(sock: sock) = data
       ) do
     sni_hostname = HandlerHelpers.try_get_sni(sock)
 
-    case Tenants.get_user_cache(type, user, tenant_or_alias, sni_hostname) do
+    case Tenants.get_user_cache(user, tenant_or_alias, sni_hostname) do
       {:ok, info} ->
         db_name = db_name || info.tenant.db_database
 
         id =
           conn_id(
-            type: type,
             tenant: tenant_or_alias,
             user: user,
             mode: data(data, :mode),
@@ -310,7 +309,6 @@ defmodule Ultravisor.ClientHandler do
           project: tenant_or_alias,
           user: user,
           mode: mode,
-          type: type,
           db_name: db_name,
           app_name: data(data, :app_name)
         )
@@ -365,7 +363,7 @@ defmodule Ultravisor.ClientHandler do
 
       {:error, reason} ->
         Logger.error(
-          "ClientHandler: User not found: #{inspect(reason)} #{inspect({type, user, tenant_or_alias})}"
+          "ClientHandler: User not found: #{inspect(reason)} #{inspect({user, tenant_or_alias})}"
         )
 
         :ok = HandlerHelpers.send_error(sock, "XX000", "Tenant or user not found")
@@ -549,7 +547,7 @@ defmodule Ultravisor.ClientHandler do
       id: id,
       auth: auth,
       user: conn_id(id, :user),
-      tenant: {:single, conn_id(id, :tenant)},
+      tenant: conn_id(id, :tenant),
       mode: :proxy,
       proxy: true,
       log_level: log_level,

--- a/lib/ultravisor/db_handler.ex
+++ b/lib/ultravisor/db_handler.ex
@@ -77,7 +77,7 @@ defmodule Ultravisor.DbHandler do
     Helpers.set_log_level(args.log_level)
     Helpers.set_max_heap_size(90)
 
-    {_, tenant} = args.tenant
+    tenant = args.tenant
     Logger.metadata(project: tenant, user: args.user, mode: args.mode)
 
     data =

--- a/lib/ultravisor/handler_helpers.ex
+++ b/lib/ultravisor/handler_helpers.ex
@@ -76,29 +76,23 @@ defmodule Ultravisor.HandlerHelpers do
   def try_get_sni(_), do: nil
 
   @spec parse_user_info(map) ::
-          {:cluster | :single, {String.t() | nil, String.t(), String.t() | nil}}
+          {String.t() | nil, String.t(), String.t() | nil}
   def parse_user_info(%{"user" => user, "options" => %{"reference" => ref}} = payload) do
     # TODO: parse ref for cluster
-    {:single, {user, ref, payload["database"]}}
+    {user, ref, payload["database"]}
   end
 
   def parse_user_info(%{"user" => user} = payload) do
     db_name = payload["database"]
 
-    case :binary.split(user, ".cluster.") do
-      [user] ->
-        case :binary.matches(user, ".") do
-          [] ->
-            {:single, {user, nil, db_name}}
+    case :binary.matches(user, ".") do
+      [] ->
+        {user, nil, db_name}
 
-          matches ->
-            {pos, 1} = List.last(matches)
-            <<name::size(pos)-binary, ?., external_id::binary>> = user
-            {:single, {name, external_id, db_name}}
-        end
-
-      [user, tenant] ->
-        {:cluster, {user, tenant, db_name}}
+      matches ->
+        {pos, 1} = List.last(matches)
+        <<name::size(pos)-binary, ?., external_id::binary>> = user
+        {name, external_id, db_name}
     end
   end
 

--- a/lib/ultravisor/manager.ex
+++ b/lib/ultravisor/manager.ex
@@ -46,9 +46,9 @@ defmodule Ultravisor.Manager do
     Helpers.set_log_level(args.log_level)
     tid = :ets.new(__MODULE__, [:protected])
 
-    [args | _] = Enum.filter(args.replicas, fn e -> e.replica_type == :write end)
+    [args | _] = args.replicas
 
-    conn_id(type: type, tenant: tenant, user: user, db_name: db_name) = args.id
+    conn_id(tenant: tenant, user: user, db_name: db_name) = args.id
 
     state = %{
       id: args.id,
@@ -62,7 +62,7 @@ defmodule Ultravisor.Manager do
       idle_timeout: args.client_idle_timeout
     }
 
-    Logger.metadata(project: tenant, user: user, type: type, db_name: db_name)
+    Logger.metadata(project: tenant, user: user, db_name: db_name)
     Registry.register(Ultravisor.Registry.ManagerTables, args.id, tid)
 
     {:ok, state}

--- a/lib/ultravisor/metrics_cleaner.ex
+++ b/lib/ultravisor/metrics_cleaner.ex
@@ -87,7 +87,6 @@ defmodule Ultravisor.MetricsCleaner do
       fn elem, acc ->
         with {{_,
                %{
-                 type: _type,
                  mode: _mode,
                  user: _user,
                  tenant: _tenant,

--- a/lib/ultravisor/secret_checker.ex
+++ b/lib/ultravisor/secret_checker.ex
@@ -24,7 +24,7 @@ defmodule Ultravisor.SecretChecker do
     Logger.debug("SecretChecker: Starting secret checker")
     tenant = Ultravisor.tenant(args.id)
 
-    %{auth: auth, user: user} = Enum.find(args.replicas, fn e -> e.replica_type == :write end)
+    %{auth: auth, user: user} = hd(args.replicas)
 
     state = %{
       tenant: tenant,

--- a/lib/ultravisor/syn_handler.ex
+++ b/lib/ultravisor/syn_handler.ex
@@ -18,7 +18,7 @@ defmodule Ultravisor.SynHandler do
   @impl true
   def on_process_unregistered(
         :tenants,
-        conn_id(type: type, tenant: tenant, user: user, mode: mode, db_name: db_name) = id,
+        conn_id(tenant: tenant, user: user, mode: mode, db_name: db_name) = id,
         _pid,
         meta,
         reason
@@ -27,8 +27,7 @@ defmodule Ultravisor.SynHandler do
       project: tenant,
       user: user,
       mode: mode,
-      db_name: db_name,
-      type: type
+      db_name: db_name
     }
 
     Logger.debug("Process unregistered: #{inspect(id)} #{inspect(reason)}", metadata)

--- a/lib/ultravisor/tenant_supervisor.ex
+++ b/lib/ultravisor/tenant_supervisor.ex
@@ -34,7 +34,7 @@ defmodule Ultravisor.TenantSupervisor do
       replicas
       |> Enum.with_index()
       |> Enum.map(fn {e, i} ->
-        id = {:pool, e.replica_type, i, args.id}
+        id = {:pool, i, args.id}
 
         %{
           id: {:pool, id},
@@ -46,7 +46,6 @@ defmodule Ultravisor.TenantSupervisor do
     children = [{Manager, args}, {SecretChecker, args} | pools]
 
     conn_id(
-      type: type,
       tenant: tenant,
       user: user,
       mode: mode,
@@ -54,7 +53,7 @@ defmodule Ultravisor.TenantSupervisor do
       search_path: search_path
     ) = args.id
 
-    map_id = %{user: user, mode: mode, type: type, db_name: db_name, search_path: search_path}
+    map_id = %{user: user, mode: mode, db_name: db_name, search_path: search_path}
     Registry.register(Ultravisor.Registry.TenantSups, tenant, map_id)
 
     Supervisor.init(children,
@@ -77,7 +76,7 @@ defmodule Ultravisor.TenantSupervisor do
     {size, overflow} = {1, args.pool_size}
 
     [
-      name: {:via, Registry, {Ultravisor.Registry.Tenants, id, args.replica_type}},
+      name: {:via, Registry, {Ultravisor.Registry.Tenants, id}},
       worker_module: Ultravisor.DbHandler,
       size: size,
       max_overflow: overflow,

--- a/lib/ultravisor/tenants.ex
+++ b/lib/ultravisor/tenants.ex
@@ -74,27 +74,26 @@ defmodule Ultravisor.Tenants do
 
   def get_tenant(_, _), do: nil
 
-  @spec get_user_cache(:single | :cluster, String.t(), String.t() | nil, String.t() | nil) ::
+  @spec get_user_cache(String.t(), String.t() | nil, String.t() | nil) ::
           {:ok, map()} | {:error, any()}
-  def get_user_cache(type, user, external_id, sni_hostname) do
-    cache_key = {:user_cache, type, user, external_id, sni_hostname}
+  def get_user_cache(user, external_id, sni_hostname) do
+    cache_key = {:user_cache, user, external_id, sni_hostname}
 
     {_, {:cached, value}} =
       Cachex.fetch(Ultravisor.Cache, cache_key, fn _key ->
-        {:commit, {:cached, get_user(type, user, external_id, sni_hostname)},
-         expire: :timer.hours(24)}
+        {:commit, {:cached, get_user(user, external_id, sni_hostname)}, expire: :timer.hours(24)}
       end)
 
     value
   end
 
-  @spec get_user(atom(), String.t(), String.t() | nil, String.t() | nil) ::
+  @spec get_user(String.t(), String.t() | nil, String.t() | nil) ::
           {:ok, map()} | {:error, any()}
-  def get_user(_, _, nil, nil) do
+  def get_user(_, nil, nil) do
     {:error, "Either external_id or sni_hostname must be provided"}
   end
 
-  def get_user(:single, user, external_id, sni_hostname) do
+  def get_user(user, external_id, sni_hostname) do
     query = build_user_query(user, external_id, sni_hostname)
 
     case Repo.all(query) do

--- a/test/ultravisor/db_handler_test.exs
+++ b/test/ultravisor/db_handler_test.exs
@@ -39,11 +39,10 @@ defmodule Ultravisor.DbHandlerTest do
       args = %{
         id: @id,
         auth: %{},
-        tenant: {:single, "test_tenant"},
+        tenant: "test_tenant",
         user_alias: "test_user_alias",
         user: "user",
         mode: :transaction,
-        replica_type: :single,
         log_level: nil,
         reconnect_retries: 5
       }

--- a/test/ultravisor/handler_helpers_test.exs
+++ b/test/ultravisor/handler_helpers_test.exs
@@ -14,7 +14,7 @@ defmodule Ultravisor.HandlerHelpersTest do
   describe "parse_user_info/1" do
     test "extracts the external_id from the username" do
       payload = %{"user" => "test.user.external_id"}
-      {:single, {name, external_id, nil}} = @subject.parse_user_info(payload)
+      {name, external_id, nil} = @subject.parse_user_info(payload)
       assert name == "test.user"
       assert external_id == "external_id"
     end
@@ -22,35 +22,29 @@ defmodule Ultravisor.HandlerHelpersTest do
     test "username consists only of username" do
       username = "username"
       payload = %{"user" => username}
-      {:single, {user, nil, nil}} = @subject.parse_user_info(payload)
+      {user, nil, nil} = @subject.parse_user_info(payload)
       assert username == user
-    end
-
-    test "consist cluster" do
-      username = "some.user.cluster.alias"
-      {t, {u, a, nil}} = @subject.parse_user_info(%{"user" => username})
-      assert {t, {u, a, nil}} == {:cluster, {"some.user", "alias", nil}}
     end
 
     test "external_id in options" do
       user = "test.user"
       external_id = "external_id"
       payload = %{"options" => %{"reference" => external_id}, "user" => user}
-      {:single, {user1, external_id1, nil}} = @subject.parse_user_info(payload)
+      {user1, external_id1, nil} = @subject.parse_user_info(payload)
       assert user1 == user
       assert external_id1 == external_id
     end
 
     test "unicode in username" do
       payload = %{"user" => "тестовe.імʼя.external_id"}
-      {:single, {name, external_id, nil}} = @subject.parse_user_info(payload)
+      {name, external_id, nil} = @subject.parse_user_info(payload)
       assert name == "тестовe.імʼя"
       assert external_id == "external_id"
     end
 
     test "extracts db_name" do
       payload = %{"user" => "user", "database" => "postgres_test"}
-      {:single, {name, nil, db_name}} = @subject.parse_user_info(payload)
+      {name, nil, db_name} = @subject.parse_user_info(payload)
       assert name == "user"
       assert db_name == "postgres_test"
     end

--- a/test/ultravisor/tenants_test.exs
+++ b/test/ultravisor/tenants_test.exs
@@ -84,10 +84,10 @@ defmodule Ultravisor.TenantsTest do
 
     test "get_user/4" do
       _tenant = tenant_fixture()
-      assert {:error, :not_found} = @subject.get_user(:single, "no_user", "no_tenant", "")
+      assert {:error, :not_found} = @subject.get_user("no_user", "no_tenant", "")
 
       assert {:ok, %{tenant: _, user: _}} =
-               @subject.get_user(:single, "postgres", "dev_tenant", "")
+               @subject.get_user("postgres", "dev_tenant", "")
     end
   end
 end

--- a/test/ultravisor_web/controllers/tenant_controller_test.exs
+++ b/test/ultravisor_web/controllers/tenant_controller_test.exs
@@ -158,13 +158,13 @@ defmodule UltravisorWeb.TenantControllerTest do
   end
 
   defp set_cache(external_id) do
-    Ultravisor.Tenants.get_user_cache(:single, "user", external_id, nil)
+    Ultravisor.Tenants.get_user_cache("user", external_id, nil)
     Ultravisor.Tenants.get_tenant_cache(external_id, nil)
   end
 
   defp check_cache(external_id) do
     assert {:ok, nil} =
-             Cachex.get(Ultravisor.Cache, {:user_cache, :single, "user", external_id, nil})
+             Cachex.get(Ultravisor.Cache, {:user_cache, "user", external_id, nil})
 
     assert {:ok, nil} = Cachex.get(Ultravisor.Cache, {:tenant_cache, external_id, nil})
   end


### PR DESCRIPTION
Clustered mode was never implemented and it was left as a scare for
future developers. Remove that information to clean up codebase and
mental load.
