### PR TITLE
chore: disable audit for Cowboy advisory

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Compile deps
       run: mix deps.compile
     - name: MixAudit check
-      run: mix deps.audit
+      run: mix deps.audit --ignore-advisory-ids GHSA-g2wm-735q-3f56
 
   sobelow:
     name: Security check


### PR DESCRIPTION
This particular issue is not a problem exploitable from external resources and is marked as "wont fix", as this applies to function that shouldn't be used directly anyway.